### PR TITLE
FA1.3x Updated Java to v17

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
           file: ./Dockerfile
           build-args: FUSIONAUTH_VERSION=${{ env.FUSIONAUTH_VERSION }}
           platforms: linux/amd64,linux/arm/v7,linux/arm64
-          push: true
+          push: false
           tags: |
             ${{ secrets.DOCKERHUB_REPO }}:latest
             ${{ secrets.DOCKERHUB_REPO }}:${{ env.FUSIONAUTH_VERSION }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
           file: ./Dockerfile
           build-args: FUSIONAUTH_VERSION=${{ env.FUSIONAUTH_VERSION }}
           # linux/amd64,linux/arm/v7,
-          platforms: linux/arm64
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
           push: false
           tags: |
             ${{ secrets.DOCKERHUB_REPO }}:latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,8 @@ jobs:
           context: .
           file: ./Dockerfile
           build-args: FUSIONAUTH_VERSION=${{ env.FUSIONAUTH_VERSION }}
-          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          # linux/amd64,linux/arm/v7,
+          platforms: linux/arm64
           push: false
           tags: |
             ${{ secrets.DOCKERHUB_REPO }}:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ ARG FUSIONAUTH_VERSION=0
 RUN ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in\
     aarch64|arm64)\
-        ESUM='ea2de929e02f2e8bd3470ee8345a63299d81dfd086ee2f0af402239a8a9615f9';\
-        BINARY_URL='https://github.com/AdoptOpenJDK/openjdk17-binaries/releases/download/jdk-2021-05-07-13-31/OpenJDK-jdk_aarch64_linux_hotspot_2021-05-06-23-30.tar.gz';\
+        ESUM='a5e954a4e89b50277f20345034aea0ccf06f53705d4ec586b268b14ff42468f7';\
+        BINARY_URL='https://download.oracle.com/java/17/archive/jdk-17.0.1_linux-aarch64_bin.tar.gz';\
         ;;\
     armhf|armv7l|armel)\
         ESUM='9fc0eada46dbf34f1583670521051a86599dabc9897c213bfbc6d7e2bfcd2bf7';\

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,24 +24,24 @@ ARG FUSIONAUTH_VERSION=0
 RUN ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in\
     aarch64|arm64)\
-        ESUM='a5e954a4e89b50277f20345034aea0ccf06f53705d4ec586b268b14ff42468f7';\
-        BINARY_URL='https://download.oracle.com/java/17/archive/jdk-17.0.1_linux-aarch64_bin.tar.gz';\
+        ESUM='f23d482b2b4ada08166201d1a0e299e3e371fdca5cd7288dcbd81ae82f3a75e3';\
+        BINARY_URL='https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.1%2B12/OpenJDK17U-jdk_aarch64_linux_hotspot_17.0.1_12.tar.gz';\
         ;;\
     armhf|armv7l|armel)\
-        ESUM='9fc0eada46dbf34f1583670521051a86599dabc9897c213bfbc6d7e2bfcd2bf7';\
-        BINARY_URL='https://github.com/AdoptOpenJDK/openjdk17-binaries/releases/download/jdk-2021-05-07-13-31/OpenJDK-jdk_arm_linux_hotspot_2021-05-06-23-30.tar.gz';\
+        ESUM='f5945a39929384235e7cb1c57df071b8c7e49274632e2a54e54b2bad05de21a5';\
+        BINARY_URL='https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.1%2B12/OpenJDK17U-jdk_arm_linux_hotspot_17.0.1_12.tar.gz';\
         ;;\
     ppc64el|ppc64le)\
-        ESUM='dcc626fc1c25460d5f37a4b0c015dc88de732fdbb08772344c36585982802704';\
-        BINARY_URL='https://github.com/AdoptOpenJDK/openjdk17-binaries/releases/download/jdk-2021-05-07-13-31/OpenJDK-jdk_ppc64le_linux_hotspot_2021-05-06-23-30.tar.gz';\
+        ESUM='bd65d4e8ecc4236924ae34d2075b956799abca594021e1b40c36aa08a0d610b0';\
+        BINARY_URL='https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.1%2B12/OpenJDK17U-jdk_ppc64le_linux_hotspot_17.0.1_12.tar.gz';\
         ;;\
     s390x)\
-        ESUM='5d690755935f7fc43417660505a8ce6d5a7a85c51817c96780d2e2e6193fc28b';\
-        BINARY_URL='https://github.com/AdoptOpenJDK/openjdk17-binaries/releases/download/jdk-2021-05-07-13-31/OpenJDK-jdk_s390x_linux_hotspot_2021-05-06-23-30.tar.gz';\
+        ESUM='dcc17e6ef28984656e997b6b8a6a31c89f45aff87a56b5d3819137c8f1050bef';\
+        BINARY_URL='https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.1%2B12/OpenJDK17U-jdk_s390x_linux_hotspot_17.0.1_12.tar.gz';\
         ;;\
     amd64|x86_64)\
-        ESUM='6f25bcb94d3e22fb52a4632c74e03b403834e81b68701ab7ecd900fb9cd89f43';\
-        BINARY_URL='https://download.oracle.com/java/17/archive/jdk-17.0.1_linux-x64_bin.tar.gz';\
+        ESUM='6ea18c276dcbb8522feeebcfc3a4b5cb7c7e7368ba8590d3326c6c3efc5448b6';\
+        BINARY_URL='https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.1%2B12/OpenJDK17U-jdk_x64_linux_hotspot_17.0.1_12.tar.gz';\
         ;;\
     *)\
         echo "Unsupported arch: ${ARCH}";\

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,24 +22,24 @@ ARG FUSIONAUTH_VERSION=0
 RUN ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in\
     aarch64|arm64)\
-        ESUM='81ca31ad90f9bd789a2ca1753d6d83d10f4927876b4a4b9f4b1c4c8cbce85feb';\
-        BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7/OpenJDK14U-jdk_aarch64_linux_hotspot_14.0.1_7.tar.gz';\
+        ESUM='ea2de929e02f2e8bd3470ee8345a63299d81dfd086ee2f0af402239a8a9615f9';\
+        BINARY_URL='https://github.com/AdoptOpenJDK/openjdk17-binaries/releases/download/jdk-2021-05-07-13-31/OpenJDK-jdk_aarch64_linux_hotspot_2021-05-06-23-30.tar.gz';\
         ;;\
     armhf|armv7l|armel)\
-        ESUM='458d091756500dc3013737aa182a14752b3d4ffc358d09532201874ffb8cae22';\
-        BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7/OpenJDK14U-jdk_arm_linux_hotspot_14.0.1_7.tar.gz';\
+        ESUM='9fc0eada46dbf34f1583670521051a86599dabc9897c213bfbc6d7e2bfcd2bf7';\
+        BINARY_URL='https://github.com/AdoptOpenJDK/openjdk17-binaries/releases/download/jdk-2021-05-07-13-31/OpenJDK-jdk_arm_linux_hotspot_2021-05-06-23-30.tar.gz';\
         ;;\
     ppc64el|ppc64le)\
-        ESUM='bfdd77112d81256d4e1a859a465dd4dcb670019a5d6cf8260c30e24a0e5947e4';\
-        BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7/OpenJDK14U-jdk_ppc64le_linux_hotspot_14.0.1_7.tar.gz';\
+        ESUM='dcc626fc1c25460d5f37a4b0c015dc88de732fdbb08772344c36585982802704';\
+        BINARY_URL='https://github.com/AdoptOpenJDK/openjdk17-binaries/releases/download/jdk-2021-05-07-13-31/OpenJDK-jdk_ppc64le_linux_hotspot_2021-05-06-23-30.tar.gz';\
         ;;\
     s390x)\
-        ESUM='c13545924e92cb9d495282e95270f299a28d5466f9741c67791f131c38ebbd0c';\
-        BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7/OpenJDK14U-jdk_s390x_linux_hotspot_14.0.1_7.tar.gz';\
+        ESUM='5d690755935f7fc43417660505a8ce6d5a7a85c51817c96780d2e2e6193fc28b';\
+        BINARY_URL='https://github.com/AdoptOpenJDK/openjdk17-binaries/releases/download/jdk-2021-05-07-13-31/OpenJDK-jdk_s390x_linux_hotspot_2021-05-06-23-30.tar.gz';\
         ;;\
     amd64|x86_64)\
-        ESUM='9ddf9b35996fbd784a53fff3e0d59920a7d5acf1a82d4c8d70906957ac146cd1';\
-        BINARY_URL='https://github.com/AdoptOpenJDK/openjdk14-binaries/releases/download/jdk-14.0.1%2B7/OpenJDK14U-jdk_x64_linux_hotspot_14.0.1_7.tar.gz';\
+        ESUM='01343d891b63c03bf00eb205987e4816feb25b9249204ebf996ef7cbc94ec4a2';\
+        BINARY_URL='https://github.com/AdoptOpenJDK/openjdk17-binaries/releases/download/jdk-2021-05-07-13-31/OpenJDK-jdk_x64_linux_hotspot_2021-05-06-23-30.tar.gz';\
         ;;\
     *)\
         echo "Unsupported arch: ${ARCH}";\

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,8 @@ RUN ARCH="$(dpkg --print-architecture)"; \
         BINARY_URL='https://github.com/AdoptOpenJDK/openjdk17-binaries/releases/download/jdk-2021-05-07-13-31/OpenJDK-jdk_s390x_linux_hotspot_2021-05-06-23-30.tar.gz';\
         ;;\
     amd64|x86_64)\
-        ESUM='01343d891b63c03bf00eb205987e4816feb25b9249204ebf996ef7cbc94ec4a2';\
-        BINARY_URL='https://github.com/AdoptOpenJDK/openjdk17-binaries/releases/download/jdk-2021-05-07-13-31/OpenJDK-jdk_x64_linux_hotspot_2021-05-06-23-30.tar.gz';\
+        ESUM='6f25bcb94d3e22fb52a4632c74e03b403834e81b68701ab7ecd900fb9cd89f43';\
+        BINARY_URL='https://download.oracle.com/java/17/archive/jdk-17.0.1_linux-x64_bin.tar.gz';\
         ;;\
     *)\
         echo "Unsupported arch: ${ARCH}";\

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,9 @@
 ###### Setup the java and fusionauth-app base #####################################################
 FROM ubuntu:bionic as build
 
-ARG JDK_MODULES=java.base,java.compiler,java.desktop,java.instrument,java.management,java.naming,java.rmi,java.security.jgss,java.security.sasl,java.sql,java.xml.crypto,jdk.attach,jdk.crypto.ec,jdk.jdi,jdk.localedata,jdk.scripting.nashorn,jdk.unsupported
+#ARG JDK_MODULES=java.base,java.compiler,java.desktop,java.instrument,java.management,java.naming,java.rmi,java.security.jgss,java.security.sasl,java.sql,java.xml.crypto,jdk.attach,jdk.crypto.ec,jdk.jdi,jdk.localedata,jdk.scripting.nashorn,jdk.unsupported
+ARG JDK_MODULES=java.base,java.compiler,java.desktop,java.instrument,java.logging,java.management,java.naming,java.rmi,java.security.jgss,java.security.sasl,java.scripting,java.sql,java.xml.crypto,jdk.attach,jdk.crypto.ec,jdk.dynalink,jdk.jdi,jdk.localedata,jdk.jpackage,jdk.unsupported,jdk.zipfs
+
 ARG FUSIONAUTH_VERSION=0
 RUN ARCH="$(dpkg --print-architecture)"; \
     case "${ARCH}" in\


### PR DESCRIPTION
Java has been updated since the v1.32 release and therefore the versions were updated on the multiarch image.
Older multiarch images used OPENJDK 14, but since 1.32 we use the adoptium JDK releases (https://github.com/adoptium) - like in the original FusionAuth docker images.